### PR TITLE
feat: add health check endpoints

### DIFF
--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,1 +1,19 @@
-console.log("api-gateway service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`api-gateway service listening on port ${PORT}`);
+});
+

--- a/blockchain-svc/src/index.ts
+++ b/blockchain-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("blockchain-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3006;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`blockchain-svc service listening on port ${PORT}`);
+});
+

--- a/metrics-svc/src/index.ts
+++ b/metrics-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("metrics-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3001;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`metrics-svc service listening on port ${PORT}`);
+});
+

--- a/network-svc/src/index.ts
+++ b/network-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("network-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3003;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`network-svc service listening on port ${PORT}`);
+});
+

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.0.0",
     "prettier": "^3.0.0",
-    "eslint-config-prettier": "^9.0.0"
+    "eslint-config-prettier": "^9.0.0",
+    "@types/node": "^20.0.0"
   }
-
 }

--- a/search-svc/src/index.ts
+++ b/search-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("search-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3002;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`search-svc service listening on port ${PORT}`);
+});
+

--- a/tx-svc/src/index.ts
+++ b/tx-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("tx-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3004;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`tx-svc service listening on port ${PORT}`);
+});
+

--- a/ws-svc/src/index.ts
+++ b/ws-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("ws-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3005;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`ws-svc service listening on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- add simple HTTP server with `/health` endpoint to every service
- include `@types/node` for type checking

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4a2be65c832eb8b1675d7c277e1b