### PR TITLE
feat: add API gateway skeleton and health checks

### DIFF
--- a/api-gateway/openapi.json
+++ b/api-gateway/openapi.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "GenesisNet API",
+    "version": "0.1.0"
+  },
+  "paths": {}
+}

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -2,5 +2,15 @@
   "name": "@genesisnet/api-gateway",
   "version": "0.0.1",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2",
+    "http-proxy-middleware": "^3.0.0",
+    "swagger-ui-express": "^4.7.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/http-proxy-middleware": "^2.0.6",
+    "@types/swagger-ui-express": "^4.1.6"
+  }
 }

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,1 +1,47 @@
-console.log("api-gateway service");
+import express from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import swaggerUi from "swagger-ui-express";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const app = express();
+const PORT = Number(process.env.PORT) || 3000;
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const spec = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "openapi.json"), "utf8")
+);
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(spec));
+
+const serviceMap: Record<string, string> = {
+  network: process.env.NETWORK_SVC_URL || "http://localhost:4001",
+  tx: process.env.TX_SVC_URL || "http://localhost:4002",
+  search: process.env.SEARCH_SVC_URL || "http://localhost:4003",
+  metrics: process.env.METRICS_SVC_URL || "http://localhost:4004",
+  ws: process.env.WS_SVC_URL || "http://localhost:4005",
+  blockchain: process.env.BLOCKCHAIN_SVC_URL || "http://localhost:4006",
+};
+
+app.use("/api/:service", (req, res, next) => {
+  const target = serviceMap[req.params.service];
+  if (!target) {
+    res.sendStatus(502);
+    return;
+  }
+
+  return createProxyMiddleware({
+    target,
+    changeOrigin: true,
+    pathRewrite: { [`^/api/${req.params.service}`]: "" },
+  })(req, res, next);
+});
+
+app.listen(PORT, () => {
+  console.log(`api-gateway service listening on port ${PORT}`);
+});

--- a/blockchain-svc/src/index.ts
+++ b/blockchain-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("blockchain-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3006;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`blockchain-svc service listening on port ${PORT}`);
+});
+

--- a/metrics-svc/src/index.ts
+++ b/metrics-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("metrics-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3001;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`metrics-svc service listening on port ${PORT}`);
+});
+

--- a/network-svc/src/index.ts
+++ b/network-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("network-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3003;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`network-svc service listening on port ${PORT}`);
+});
+

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.0.0",
     "prettier": "^3.0.0",
-    "eslint-config-prettier": "^9.0.0"
+    "eslint-config-prettier": "^9.0.0",
+    "@types/node": "^20.0.0"
   }
-
 }

--- a/search-svc/src/index.ts
+++ b/search-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("search-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3002;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`search-svc service listening on port ${PORT}`);
+});
+

--- a/tx-svc/src/index.ts
+++ b/tx-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("tx-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3004;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`tx-svc service listening on port ${PORT}`);
+});
+

--- a/ws-svc/src/index.ts
+++ b/ws-svc/src/index.ts
@@ -1,1 +1,19 @@
-console.log("ws-svc service");
+import http from "node:http";
+
+const PORT = Number(process.env.PORT) || 3005;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`ws-svc service listening on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- add simple HTTP server with `/health` endpoint to every service
- set up Express API gateway with `/api/:service` proxy and basic OpenAPI docs

## Testing
- `npm install -w api-gateway express http-proxy-middleware swagger-ui-express` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4a2be65c832eb8b1675d7c277e1b