### PR TITLE
feat(api-gateway): add security middleware and logging

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -7,11 +7,18 @@
     "express": "^4.19.2",
     "http-proxy-middleware": "^3.0.0",
     "swagger-ui-express": "^4.7.0",
+    "cors": "^2.8.5",
+    "helmet": "^7.0.0",
+    "morgan": "^1.10.0",
+    "winston": "^3.10.0",
     "@genesisnet/env": "0.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/http-proxy-middleware": "^2.0.6",
-    "@types/swagger-ui-express": "^4.1.6"
+    "@types/swagger-ui-express": "^4.1.6",
+    "@types/cors": "^2.8.17",
+    "@types/morgan": "^1.9.4",
+    "@types/helmet": "^4.0.0"
   }
 }

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -2,13 +2,25 @@
 import express from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import swaggerUi from "swagger-ui-express";
+import cors from "cors";
+import helmet from "helmet";
+import morgan from "morgan";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { env } from "@genesisnet/env";
+import { logger } from "./logger";
 
 const app = express();
 const PORT = env.API_GATEWAY_PORT;
+
+app.use(cors());
+app.use(helmet());
+app.use(
+  morgan("combined", {
+    stream: { write: (message) => logger.info(message.trim()) },
+  })
+);
 
 app.get("/health", (_req, res) => {
   res.json({ ok: true });
@@ -45,6 +57,6 @@ app.use("/api/:service", (req, res, next) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`api-gateway service listening on port ${PORT}`);
+  logger.info(`api-gateway service listening on port ${PORT}`);
 });
 

--- a/api-gateway/src/logger.ts
+++ b/api-gateway/src/logger.ts
@@ -1,0 +1,10 @@
+import winston from "winston";
+
+export const logger = winston.createLogger({
+  level: "info",
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json()
+  ),
+  transports: [new winston.transports.Console()],
+});


### PR DESCRIPTION
## Summary
- add CORS and Helmet for basic security
- log incoming requests with Morgan and Winston

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689cb4710330832ea10c38d4aa53ec0b