### PR TITLE
feat: add activity log middleware

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -11,7 +11,8 @@
     "helmet": "^7.0.0",
     "morgan": "^1.10.0",
     "winston": "^3.10.0",
-    "@genesisnet/env": "0.0.1"
+    "@genesisnet/env": "0.0.1",
+    "@genesisnet/activity-log": "0.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { env } from "@genesisnet/env";
 import { logger } from "./logger";
+import { activityLogger, errorLogger } from "@genesisnet/activity-log";
 
 const app = express();
 const PORT = env.API_GATEWAY_PORT;
@@ -21,6 +22,7 @@ app.use(
     stream: { write: (message) => logger.info(message.trim()) },
   })
 );
+app.use(activityLogger);
 
 app.get("/health", (_req, res) => {
   res.json({ ok: true });
@@ -55,6 +57,8 @@ app.use("/api/:service", (req, res, next) => {
     pathRewrite: { [`^/api/${req.params.service}`]: "" },
   })(req, res, next);
 });
+
+app.use(errorLogger);
 
 app.listen(PORT, () => {
   logger.info(`api-gateway service listening on port ${PORT}`);

--- a/packages/activity-log/package.json
+++ b/packages/activity-log/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@genesisnet/activity-log",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "pg": "^8.11.0",
+    "@genesisnet/env": "0.0.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
+  }
+}

--- a/packages/activity-log/src/index.ts
+++ b/packages/activity-log/src/index.ts
@@ -1,0 +1,47 @@
+import { Pool } from 'pg';
+import { env } from '@genesisnet/env';
+import { Request, Response, NextFunction } from 'express';
+
+const pool = new Pool({ connectionString: env.DB_URL });
+
+type ActivityEvent = 'api_access' | 'error' | 'data_change';
+
+async function logActivity(event: ActivityEvent, details: unknown) {
+  try {
+    await pool.query(
+      `INSERT INTO activity_logs (event_type, details) VALUES ($1, $2::jsonb)`,
+      [event, JSON.stringify(details)]
+    );
+  } catch {
+    // ignore logging errors
+  }
+}
+
+export function activityLogger(req: Request, res: Response, next: NextFunction) {
+  const start = Date.now();
+  res.on('finish', () => {
+    logActivity('api_access', {
+      method: req.method,
+      path: req.originalUrl,
+      status: res.statusCode,
+      duration: Date.now() - start,
+    });
+  });
+  next();
+}
+
+export function errorLogger(err: Error, req: Request, _res: Response, next: NextFunction) {
+  logActivity('error', {
+    method: req.method,
+    path: req.originalUrl,
+    message: err.message,
+    stack: err.stack,
+  });
+  next(err);
+}
+
+export function logDataChange(action: string, entity: string, before: unknown, after: unknown) {
+  return logActivity('data_change', { action, entity, before, after });
+}
+
+export { logActivity };

--- a/packages/activity-log/tsconfig.json
+++ b/packages/activity-log/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add shared activity log middleware to write API access, errors, and data changes to `activity_logs`
- wire middleware into API gateway for request and error logging

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js'; attempted `npm install` but registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cb679d80c832ea696af20e7f8d451