### PR TITLE
chore: setup database migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: genesisnet
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_URL: postgres://postgres:postgres@localhost:5432/genesisnet
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run db:migrate

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "lint:fix": "eslint . --ext .ts,.tsx --fix"
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "db:migrate": "knex --knexfile packages/db/knexfile.cjs migrate:latest",
+    "db:reset": "knex --knexfile packages/db/knexfile.cjs migrate:rollback --all && npm run db:migrate",
+    "db:seed": "knex --knexfile packages/db/knexfile.cjs seed:run"
   },
   "workspaces": [
     "api-gateway",
@@ -37,6 +40,8 @@
     "typescript-eslint": "^8.0.0",
     "prettier": "^3.0.0",
     "eslint-config-prettier": "^9.0.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "knex": "^2.5.1",
+    "pg": "^8.11.1"
   }
 }

--- a/packages/db/knexfile.cjs
+++ b/packages/db/knexfile.cjs
@@ -1,0 +1,16 @@
+/** @type {import('knex').Knex.Config} */
+module.exports = {
+  client: 'pg',
+  connection: process.env.DB_URL || 'postgres://postgres:postgres@localhost:5432/genesisnet',
+  migrations: {
+    tableName: 'knex_migrations',
+    directory: './migrations'
+  },
+  seeds: {
+    directory: './seeds'
+  },
+  pool: {
+    min: 2,
+    max: 10
+  }
+};

--- a/packages/db/migrations/001_init.js
+++ b/packages/db/migrations/001_init.js
@@ -1,0 +1,14 @@
+/** @param {import('knex').Knex} knex */
+exports.up = async function(knex) {
+  await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "pgcrypto"');
+  await knex.schema.createTable('users', table => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.string('email').notNullable();
+    table.timestamps(true, true);
+  });
+};
+
+/** @param {import('knex').Knex} knex */
+exports.down = async function(knex) {
+  await knex.schema.dropTable('users');
+};

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@genesisnet/db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "async-retry": "^1.3.3",
+    "pg": "^8.11.1",
+    "knex": "^2.5.1"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.10.0"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,18 @@
+import { Pool } from 'pg';
+import retry from 'async-retry';
+
+const connectionString = process.env.DB_URL ?? 'postgres://postgres:postgres@localhost:5432/genesisnet';
+
+export const pool = new Pool({ connectionString });
+
+export async function connectWithRetry(): Promise<void> {
+  await retry(async () => {
+    await pool.query('SELECT 1');
+  }, {
+    retries: 5,
+    factor: 2,
+    minTimeout: 1000
+  });
+}
+
+export default pool;

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add shared db package with connection pool and retry
- introduce Knex migrations and initial users table
- wire up CI to run migrations

## Testing
- `npm test`
- `npm run db:migrate` *(fails: knex: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689cc7fe29d4832e9f42b1b603044ce0